### PR TITLE
Add babel-core as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "babel-core": "^6.18.2",
     "babel-loader": "^6.1.0",
     "babel-preset-es2015": "^6.1.18",
     "babel-polyfill": "^6.3.14",


### PR DESCRIPTION
Fixes https://github.com/rauschma/webpack-babel-demo/issues/2:

When running npm run build I'm getting _ERROR in Cannot find module 'babel-core'_